### PR TITLE
temporary fix for Sketch 3.9+

### DIFF
--- a/sketch-export-generator.sketchplugin/Contents/Sketch/export.cocoascript
+++ b/sketch-export-generator.sketchplugin/Contents/Sketch/export.cocoascript
@@ -60,8 +60,10 @@ function compare(a, b) {
 function prepareExportSizes(layer) {
   //log('=== ' + layer.name() + ' ===');
   //log('Remove all export sizes of layer \'' + layer.name() + '\'.');
-  var sizes = layer.exportOptions().exportFormats()
-  sizes.removeAllObjects();
+  var sizes = layer.exportOptions().exportFormats();
+
+  // line below is commented to fix a Sketch 3.9 issue: https://github.com/kang-chen/sketch-export-generator/issues/5
+  //sizes.removeAllObjects();
 
   //SIZES.sort(compare);
   //SCALES.sort(compare);


### PR DESCRIPTION
line is commented to fix a Sketch 3.9 issue:
https://github.com/kang-chen/sketch-export-generator/issues/5

It is a temporary workaround, until Bohemiancoding updates the Export section of their docs which is 'in progress': 
http://developer.sketchapp.com/reference/action/Export/

For now there is no solution because of `@property(readonly, nonatomic) NSArray *exportFormats;`:
https://github.com/abynim/Sketch-Headers/blob/master/Headers/MSExportOptions.h
