### PR TITLE
. changed the export sizes/ratios to adapt them to our needs; . added the ldpi to Android export.

### DIFF
--- a/sketch-export-generator.sketchplugin/Contents/Sketch/handler.cocoascript
+++ b/sketch-export-generator.sketchplugin/Contents/Sketch/handler.cocoascript
@@ -4,9 +4,9 @@
 var exportIOS = function(context) {
   //setScale([1,2,3]);
   setScale([
-    {size: 1, suffix: ""},
-    {size: 2, suffix: "@2x"},
-    {size: 3, suffix: "@3x"}
+    {size: 0.50, suffix: ""},
+    {size: 1, suffix: "@2x"},
+    {size: 1.5, suffix: "@3x"}
   ])
 	runExportIOS(context);
   context.document.showMessage("iOS Exports added");
@@ -14,20 +14,22 @@ var exportIOS = function(context) {
 
 var exportAndroid = function(context) {
   /*
-  mdpi = ~160dpi = 1×, or 100%
-  hdpi = ~240dpi = 1.5×, or 150%
-  xhdpi = ~320dpi = 2×, or 200%
-  xxhdpi = ~480dpi = 3×, or 300%
-  xxxhdpi = ~640dpi = 4×, or 400%
+  ldpi = ~121dpi = 0.38x, or 38%
+  mdpi = ~160dpi = 0.5×, or 50%
+  hdpi = ~240dpi = 0.75×, or 75%
+  xhdpi = ~320dpi = 1×, or 100%
+  xxhdpi = ~480dpi = 1.5×, or 150%
+  xxxhdpi = ~640dpi = 2×, or 200%
   */
   //setScale([1,1.5,2,3]);
 
   setScale([
-    {size: 1, suffix: "-mdpi"},
-    {size: 1.5, suffix: "-hdpi"},
-    {size: 2, suffix: "-xhdpi"},
-    {size: 3, suffix: "-xxhdpi"},
-    {size: 4, suffix: "-xxxhdpi"}
+    {size: 0.38, suffix: "_ldpi"},
+    {size: 0.5, suffix: "_mdpi"},
+    {size: 0.75, suffix: "_hdpi"},
+    {size: 1, suffix: "_xhdpi"},
+    {size: 1.5, suffix: "_xxhdpi"},
+    {size: 2, suffix: "_xxxhdpi"}
   ])
 	runExportAndroid(context);
   context.document.showMessage("Android Exports added");
@@ -36,14 +38,15 @@ var exportAndroid = function(context) {
 var exportAll = function(context) {
 
   setScale([
-    {size: 1, suffix: ""},
-    {size: 2, suffix: "@2x"},
-    {size: 3, suffix: "@3x"},
-    {size: 1, suffix: "-mdpi"},
-    {size: 1.5, suffix: "-hdpi"},
-    {size: 2, suffix: "-xhdpi"},
-    {size: 3, suffix: "-xxhdpi"},
-    {size: 4, suffix: "-xxxhdpi"}
+    {size: 0.5, suffix: ""},
+    {size: 1, suffix: "@2x"},
+    {size: 1.5, suffix: "@3x"},
+    {size: 0.38, suffix: "_ldpi"},
+    {size: 0.5, suffix: "_mdpi"},
+    {size: 0.75, suffix: "_hdpi"},
+    {size: 1, suffix: "_xhdpi"},
+    {size: 1.5, suffix: "_xxhdpi"},
+    {size: 2, suffix: "_xxxhdpi"}
   ])
   runExport(context);
   context.document.showMessage("iOS and Android Exports added");

--- a/sketch-export-generator.sketchplugin/Contents/Sketch/manifest.json
+++ b/sketch-export-generator.sketchplugin/Contents/Sketch/manifest.json
@@ -42,5 +42,5 @@
   "version" : "1.0.0",
   "description" : "A simple plugin to add iOS and Android exports with shortcut.",
   "authorEmail" : "me@philippehong.com",
-  "name" : "Sketch Export Generator"
+  "name" : "Sketch Export Generator @2x"
 }


### PR DESCRIPTION
Hi!

First of all: I am pretty new to all this, so please accept my apologies if I've done anything wrong.

Our designers usually work on Sketch using "2x" as their default format, so I played a little bit with your settings to adapt them to my needs.

At the same time, I added the 'ldpi' format to your Android exports.
I know it's not really much used anymore, but you never know... :)

Best regards,
davide